### PR TITLE
Add "Copy Line Reference" functionality

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,8 @@ module.exports = new class {
       "copy-path:copy-full-path": (e) => this.copyFullPath(e),
       "copy-path:copy-base-dirname": (e) => this.copyBaseDirname(e),
       "copy-path:copy-project-relative-dirname": (e) => this.copyProjectRelativeDirname(e),
-      "copy-path:copy-full-dirname": (e) => this.copyFullDirname(e)
+      "copy-path:copy-full-dirname": (e) => this.copyFullDirname(e),
+      "copy-path:copy-line-reference": (e) => this.copyLineReference(e)
     }));
   }
 
@@ -94,4 +95,10 @@ module.exports = new class {
     atom.clipboard.write(dir);
   }
 
+  copyLineReference(e) {
+    const editor = atom.workspace.getActiveTextEditor();
+    const lineNumber = editor.getCursorBufferPosition().row + 1;
+    const relativePath = this.getProjectRelativePath(editor.getPath());
+    atom.clipboard.write(`${relativePath}:${lineNumber}`);
+  }
 };

--- a/menus/copy-path.cson
+++ b/menus/copy-path.cson
@@ -38,6 +38,17 @@ menu: [
   }
 ]
 "context-menu":
+  "atom-text-editor": [
+    {
+      label: "Copy Path"
+      submenu: [
+        {
+          label: "Copy Line Reference"
+          command: "copy-path:copy-line-reference"
+        }
+      ]
+    }
+  ]
   ".tab": [
     {
       label: "Copy Path"


### PR DESCRIPTION
This PR adds tiny context menu for text editor with 1 option called "Copy Line Reference" which copies relative project path with line number of current cursor. E.g. "test/my_class.coffee:25".
