### PR TITLE
Move the menu into the submenus of "Packages".

### DIFF
--- a/menus/copy-path.cson
+++ b/menus/copy-path.cson
@@ -1,41 +1,44 @@
 menu: [
-  {
-    label: "Copy Path"
-    submenu: [
-      {
-        label: "Copy Basename"
-        command: "copy-path:copy-basename"
-      }
-      {
-        label: "Copy Extension"
-        command: "copy-path:copy-extension"
-      }
-      {
-        label: "Copy Basename w/o Extension"
-        command: "copy-path:copy-basename-wo-extension"
-      }
-      {
-        label: "Copy Project-Relative Path"
-        command: "copy-path:copy-project-relative-path"
-      }
-      {
-        label: "Copy Full Path"
-        command: "copy-path:copy-full-path"
-      }
-      {
-        label: "Copy Base Dirname"
-        command: "copy-path:copy-base-dirname"
-      }
-      {
-        label: "Copy Project-Relative Dirname"
-        command: "copy-path:copy-project-relative-dirname"
-      }
-      {
-        label: "Copy Full Dirname"
-        command: "copy-path:copy-full-dirname"
-      }
-    ]
-  }
+  label: "Packages"
+  submenu: [
+    {
+      label: "Copy Path"
+      submenu: [
+        {
+          label: "Copy Basename"
+          command: "copy-path:copy-basename"
+        }
+        {
+          label: "Copy Extension"
+          command: "copy-path:copy-extension"
+        }
+        {
+          label: "Copy Basename w/o Extension"
+          command: "copy-path:copy-basename-wo-extension"
+        }
+        {
+          label: "Copy Project-Relative Path"
+          command: "copy-path:copy-project-relative-path"
+        }
+        {
+          label: "Copy Full Path"
+          command: "copy-path:copy-full-path"
+        }
+        {
+          label: "Copy Base Dirname"
+          command: "copy-path:copy-base-dirname"
+        }
+        {
+          label: "Copy Project-Relative Dirname"
+          command: "copy-path:copy-project-relative-dirname"
+        }
+        {
+          label: "Copy Full Dirname"
+          command: "copy-path:copy-full-dirname"
+        }
+      ]
+    }
+  ]
 ]
 "context-menu":
   "atom-text-editor": [


### PR DESCRIPTION
"Copy Path" menu should be placed in the submenu of "Packages" menu. (I don't remember why I did that though)
