### PR TITLE
[feature] Copy Project Relative Path for Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The path of the active text editor is copied.
 * `copy-path:copy-project-relative-dirname`
 * `copy-path:copy-full-dirname`
 * `copy-path:copy-line-reference`
+* `copy-path:copy-project-relative-path-web`
 
 ## License
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,8 @@ module.exports = new class {
       "copy-path:copy-base-dirname": (e) => this.copyBaseDirname(e),
       "copy-path:copy-project-relative-dirname": (e) => this.copyProjectRelativeDirname(e),
       "copy-path:copy-full-dirname": (e) => this.copyFullDirname(e),
-      "copy-path:copy-line-reference": (e) => this.copyLineReference(e)
+      "copy-path:copy-line-reference": (e) => this.copyLineReference(e),
+      "copy-path:copy-project-relative-path-web": (e) => this.copyProjectRelativePathForWeb(e),
     }));
   }
 
@@ -100,5 +101,10 @@ module.exports = new class {
     const lineNumber = editor.getCursorBufferPosition().row + 1;
     const relativePath = this.getProjectRelativePath(editor.getPath());
     atom.clipboard.write(`${relativePath}:${lineNumber}`);
+  }
+
+  copyProjectRelativePathForWeb(e) {
+    var path = this.getProjectRelativePath(this.getTargetEditorPath(e)).replace(/\\/g, '/');
+    atom.clipboard.write(path);
   }
 };

--- a/menus/copy-path.cson
+++ b/menus/copy-path.cson
@@ -36,6 +36,10 @@ menu: [
           label: "Copy Full Dirname"
           command: "copy-path:copy-full-dirname"
         }
+        {
+          label: "Copy Project-Relative Path for Web"
+          command: "copy-path:copy-project-relative-path-web"
+        }
       ]
     }
   ]
@@ -87,6 +91,10 @@ menu: [
         {
           label: "Copy Full Dirname"
           command: "copy-path:copy-full-dirname"
+        }
+        {
+          label: "Copy Project-Relative Path for Web"
+          command: "copy-path:copy-project-relative-path-web"
         }
       ]
     }


### PR DESCRIPTION
On Windows, the relative Path (and all other) are copied with backward slashes as is correct.
But when inserting it in html documents for css or js references a foreward slash is preferred.

So this extra menu item copies the project relative path and replaces all backward slashes with foreward ones.

Are you cool with merging this feature? @s-shin 
