### PR TITLE
Stop using reserved JavaScript keyword `package`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,11 +30,11 @@ module.exports = new class {
     this.subscriptions.add(atom.commands.add("atom-workspace", {
       "copy-path:copy-project-relative-path-web": (e) => this.copyProjectRelativePathForWeb(e)
     }));
-    atom.packages.onDidActivatePackage((pack) => {
-      if (pack.name !== "copy-path") {
+    atom.packages.onDidActivatePackage((pkg) => {
+      if (pkg.name !== "copy-path") {
         return;
       }
-      pack.menuManager.add([
+      pkg.menuManager.add([
         {
           label: "Packages",
           submenu: [
@@ -50,7 +50,7 @@ module.exports = new class {
           ]
         }
       ]);
-      pack.contextMenuManager.add({
+      pkg.contextMenuManager.add({
         ".tab": [
           {
             label: "Copy Path",

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,11 +30,11 @@ module.exports = new class {
     this.subscriptions.add(atom.commands.add("atom-workspace", {
       "copy-path:copy-project-relative-path-web": (e) => this.copyProjectRelativePathForWeb(e)
     }));
-    atom.packages.onDidActivatePackage((package) => {
-      if (package.name !== "copy-path") {
+    atom.packages.onDidActivatePackage((pack) => {
+      if (pack.name !== "copy-path") {
         return;
       }
-      package.menuManager.add([
+      pack.menuManager.add([
         {
           label: "Packages",
           submenu: [
@@ -50,7 +50,7 @@ module.exports = new class {
           ]
         }
       ]);
-      package.contextMenuManager.add({
+      pack.contextMenuManager.add({
         ".tab": [
           {
             label: "Copy Path",


### PR DESCRIPTION
In the process of upgrading babel in Atom core (https://github.com/atom/atom/pull/13823) we have noticed this package uses JavaScript features that are either deprecated or that are incompatible with the language specification.

This pull request changes the code to stop using such features so that the package keeps working when the babel upgrade will be merged and released.

I have enabled edits from maintainers, so feel free to make any changes to this branch! Also, please let me know if you have any questions or concerns and if I can help somehow. Thanks!