### PR TITLE
Fix bug: atom.workspace.getActivePaneItem(...).getPath is not a function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,22 +71,25 @@ module.exports = new class {
   }
 
   getTargetEditorPath(e) {
-    // tab's context menu
-    var elTarget;
+    var titleElement;
+
+    titleElement = e.target.querySelector(".title");
+    if (titleElement) {
+      return titleElement.dataset.path;
+    }
+
     if (e.target.classList.contains("title")) {
-      elTarget = e.target;
-    } else {
-      // find .tab
-      for (let i = 0; i < 100; i++) {
-        const el = e.target.parentElement;
-        if (el && el.classList.contains("tab")) {
-          elTarget = el.querySelector(".title");
-        }
+      return e.target.dataset.path;
+    }
+
+    // find .tab
+    for (let i = 0; i < 100; i++) {
+      const el = e.target.parentElement;
+      if (el && el.classList.contains("tab")) {
+        return el.querySelector(".title").dataset.path;
       }
     }
-    if (elTarget) {
-      return elTarget.dataset.path;
-    }
+
     // command palette etc.
     return atom.workspace.getActivePaneItem().getPath();
   }


### PR DESCRIPTION
When I click on unfocused tab, Atom raise:
```
Uncaught TypeError: atom.workspace.getActivePaneItem(...).getPath is not a function
```
which is described in https://github.com/s-shin/atom-copy-path/issues/10

I use `debugger` in `getTargetEditorPath` function and found out that `e.target` is the element which has `tab` class and contains `.title` element.

So we should check if `e.target` contains `.title` element and return the path of `.title` element if it does.