### PR TITLE
Fix issue with finding path when right clicking on a tab

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,8 +81,11 @@ module.exports = new class {
 
     // If the event was emitted by "context-menu".".tab" (see copy-path.cson),
     // e.currentTarget must be .tab element.
-    if (e.currentTarget.classList.contains("tab")) {
-      const elTitle = e.currentTarget.querySelector(".title");
+    tab = e.currentTarget.classList.contains("tab") ?
+      e.currentTarget :
+      e.target.closest('.tab');
+    if (tab) {
+      const elTitle = tab.querySelector(".title");
       if (elTitle && elTitle.dataset.path) {
         return elTitle.dataset.path;
       }


### PR DESCRIPTION
### Why

Some strange reasons, it looks like when right clicking on a tab, the `currentTarget` is deemed to be the `workspace` element, and not the `.tab` element.

This means when right clicking on a tab which is not active, it doesn't copy anything at all (or copies the path of another tab if the one we clicked is inactive and there is an active one).

<img width="583" alt="screen shot 2017-08-12 at 11 14 00" src="https://user-images.githubusercontent.com/2564173/29239821-6968d46a-7f4f-11e7-809a-2bcd187a29b9.png">

### What

Improve the `getTargetEditorPath` to find the tab based on the actual `target` if the happy path was not feasible.