### PR TITLE
Show notification when something is copied into clipboard

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -101,6 +101,11 @@ module.exports = new class {
       return;
     }
     atom.clipboard.write(str);
+    var notif = atom.notifications.addSuccess(`\`${str}\``, {
+      dismissable: true,
+      description: 'Copied to clipboard'
+    });
+    setTimeout(() => notif.dismiss(), 2000)
   }
 
   parseTargetEditorPath(e) {


### PR DESCRIPTION
### Why

It is currently impossible to tell if anything has happened at all when copying some path.

There are times that for some reason path is not copied, but the user wound't notice until they try to paste somewhere else.

### What

Just simply show a notification (that disappears in 2 sec).

<img width="609" alt="screen shot 2017-08-12 at 11 17 19" src="https://user-images.githubusercontent.com/2564173/29239835-d4080908-7f4f-11e7-9dd2-5f1fd23ebe72.png">
