### PR TITLE
Fixed #19 and #21.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,15 +74,11 @@ module.exports = new class {
     // NOTE: DOM tree around a tab is like:
     //
     // ul.tab-bar
-    //   li.tab ... (1)
-    //     div.title[data-path=<absolute-path>] ... (2)
-    //
-    // Opening the context menu on the tab, the target element will be (1) or (2).
-
-    // If the event was emitted by "context-menu".".tab" (see copy-path.cson),
-    // e.currentTarget must be .tab element.
-    if (e.currentTarget.classList.contains("tab")) {
-      const elTitle = e.currentTarget.querySelector(".title");
+    //   li.tab
+    //     div.title[data-path=<absolute-path>]
+    const tab = e.target.closest(".tab");
+    if (tab) {
+      const elTitle = tab.querySelector(".title");
       if (elTitle && elTitle.dataset.path) {
         return elTitle.dataset.path;
       }
@@ -93,7 +89,7 @@ module.exports = new class {
     if (!item) {
       return ""; // no active pane
     }
-    return item.getPath ? item.getPath() : "";
+    return (item.getPath && item.getPath()) || "";
   }
 
   writeToClipboardIfValid(str) {


### PR DESCRIPTION
* https://github.com/s-shin/atom-copy-path/pull/19 will be simply fixed by replacing `e.currentTarget` to `e.target.closest('.tab')`.
* https://github.com/s-shin/atom-copy-path/issues/21 is caused by returning `undefined` that is generated by `item.getPath()`