### PR TITLE
Preprocess paths to always make them Unix format

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Copy a file path flexibly!
 
+Always in Unix format: `/path/to/file`, even if running on Windows.
+
 ## Context Menu on a Tab
 
 ![capture](https://raw.githubusercontent.com/s-shin/atom-copy-path/master/capture.png)

--- a/lib/index.js
+++ b/lib/index.js
@@ -110,8 +110,23 @@ module.exports = new class {
 
   getProjectRelativePath(p) {
     [projectPath, relativePath] = atom.project.relativizePath(p);
-    return relativePath;
+    return this.preprocessPath(relativePath);
   }
+
+  //-------------------------------------
+
+  convertDosToUnix(p) {
+    return p.replace(/\\/g,"/");
+  }
+
+  // Single-point path preprocessor.
+  preprocessPath(p) {
+    // Currently we force-preprocess all to Unix.
+    // Might be made a configurable option in the future.
+    return this.convertDosToUnix(p);
+  }
+
+  //-------------------------------------
 
   copyBasename(e) {
     const {base} = this.parseTargetEditorPath(e);
@@ -133,7 +148,7 @@ module.exports = new class {
   }
 
   copyFullPath(e) {
-    this.writeToClipboardIfValid(this.getTargetEditorPath(e));
+    this.writeToClipboardIfValid(this.preprocessPath(this.getTargetEditorPath(e)));
   }
 
   copyBaseDirname(e) {
@@ -148,7 +163,7 @@ module.exports = new class {
 
   copyFullDirname(e) {
     const {dir} = this.parseTargetEditorPath(e);
-    this.writeToClipboardIfValid(dir);
+    this.writeToClipboardIfValid(this.preprocessPath(dir));
   }
 
   copyLineReference(e) {


### PR DESCRIPTION
* `\path\to\file` becomes `/path/to/file`.

- - -

Hey Shintaro,

Please consider this. I've made path conversion (DOS->Unix) unconditional (I don't need native backslashed paths for anything). However, it could be a great feature to make such conversion configurable through package's "Settings" page.

My limited knowledge of Atom doesn't let me implement the setting myself. Please consider. Might be a great feature for the public.

Cheers,
Alex